### PR TITLE
Fixed #2: allow multiple s, p, o, and also operators

### DIFF
--- a/triple-range-constraint.xqy
+++ b/triple-range-constraint.xqy
@@ -32,8 +32,11 @@ declare function constraint:query(
 declare private function constraint:get-data($vals) {
   for $v in $vals
   return
-    if (starts-with($v, "<") and ends-with($v, ">")) then
-      sem:iri(substring($v, 2, string-length($v) - 2))
+    if ($v/search:value) then
+      if ($v/search:datatype) then
+        sem:typed-literal($v/search:value, sem:iri($v/search:datatype))
+      else
+        data($v/search:value)
     else
-      data($v)
+      sem:iri($v)
 };

--- a/triple-range-constraint.xqy
+++ b/triple-range-constraint.xqy
@@ -2,35 +2,38 @@ xquery version "1.0-ml";
 
 module namespace constraint = "http://marklogic.com/constraint/triple-range-constraint";
 
-import module namespace search =
-  "http://marklogic.com/appservices/search"
-    at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search = "http://marklogic.com/appservices/search"
+  at "/MarkLogic/appservices/search/search.xqy";
+
+declare default function namespace "http://www.w3.org/2005/xpath-functions";
+
+declare option xdmp:mapping "false";
 
 declare function constraint:query(
   $query-elem as element(),
   $options as element(search:options)
 ) as schema-element(cts:query)
 {
-  let $subject := $query-elem/search:subject
-  let $subject := if (exists($subject))
-    then string($subject)
-    else ()
-  let $predicate := $query-elem/search:predicate
-  let $predicate := if (exists($predicate))
-    then string($predicate)
-    else ()
-  let $object := $query-elem/search:object
-  let $object := if (exists($object))
-    then string($object)
-    else ()
+  let $subjects := constraint:get-data($query-elem/search:subject)
+  let $predicates := constraint:get-data($query-elem/search:predicate)
+  let $objects := constraint:get-data($query-elem/search:object)
+  let $operators := constraint:get-data($query-elem/search:operator)
+
+  return document{
+    cts:triple-range-query(
+      $subjects,
+      $predicates,
+      $objects,
+      $operators
+    )
+  }/*
+};
+
+declare private function constraint:get-data($vals) {
+  for $v in $vals
   return
-    <cts:triple-range-query>
-      {
-        <x>{cts:triple-range-query(
-           sem:iri($subject),
-           sem:iri($predicate),
-           sem:iri($object)
-        )}</x>/*/*
-      }
-    </cts:triple-range-query>
+    if (starts-with($v, "<") and ends-with($v, ">")) then
+      sem:iri(substring($v, 2, string-length($v) - 2))
+    else
+      data($v)
 };


### PR DESCRIPTION
#2 This PR allows providing (optional) sequences for subject, predicate, and object. It also supports providing range operators to allow inequality tests. It also makes a more clear distinction between iris and values.

Note: because of the last bit, it is not entirely backwards compatible. I saw no way to avoid this, and make it work for my own needs (the sem-doc demo) at the same time. This is what we ended up using..
